### PR TITLE
Updating jQuery version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "coffee-script": "~1.7.1",
     "grunt": "~0.4.5",
     "mocha": "~1.20.1",
-    "jquery": "~3.3.1",
+    "jquery": "~3.5.0",
     "jsdom": "~0.11.1",
     "mocha-jenkins-reporter": "~0.1.0",
     "should": "~4.0.4",


### PR DESCRIPTION
There's a security vulnerability in the version of jQuery listed as a requirement, so we should update it to a more current and secure version.